### PR TITLE
feat: add version selector for negrutiu distro

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,16 @@ NSIS distribution to install:
 
 Default is `negrutiu`
 
+### version
+
+NSIS version to install:
+- A GitHub tag pointing to a valid release, e.g. 'v3.12.7487.317'
+
+Default is `latest`
+
+> [!IMPORTANT]
+> `official` distro is not supported.
+
 ### `arch`
 
 NSIS compiler architecture to install:

--- a/action.py
+++ b/action.py
@@ -358,7 +358,7 @@ def nsis_list():
     return installations
 
 
-def nsis_install(arch, distro='negrutiu', instdir=None, register_path=True, github_token=None):
+def nsis_install(arch, distro='negrutiu', version_in='latest', instdir=None, register_path=True, github_token=None):
     """ Download and install the latest [negrutiu/nsis](https://github.com/negrutiu/nsis) release.
         Returns:
             `(instdir, version, arch)` or raises on error. """
@@ -380,7 +380,7 @@ def nsis_install(arch, distro='negrutiu', instdir=None, register_path=True, gith
 
     # download
     if distro.lower() == 'negrutiu':
-        installer = download_github_asset('negrutiu', 'nsis', 'latest', rf'nsis-.*-{arch}\.exe', github_token, downloadsdir)
+        installer = download_github_asset('negrutiu', 'nsis', version_in, rf'nsis-.*-{arch}\.exe', github_token, downloadsdir)
         version = re.search(rf'nsis-(.+)-.*-{arch}\.exe', os.path.basename(installer)).group(1)   # "nsis-3.11.7461.288-negrutiu-x86.exe" => "3.11.7461.288"
         assert version, f'-- failed to parse version from "{installer}"'
     elif distro.lower() == 'official':

--- a/action.yml
+++ b/action.yml
@@ -13,6 +13,14 @@ inputs:
     default: negrutiu
     required: false
 
+  version:        # available since v3
+    description: ^
+      NSIS version to install.
+      If `negrutiu` distro is selected, this should be a GitHub tag pointing to a valid release, e.g. 'v3.12.7487.317'.
+      If `official` distro is selected, this option is invalid and will not have any effect.
+    default: 'latest'
+    required: false
+
   arch:
     description: ^ 
       NSIS architecture to install.
@@ -108,6 +116,7 @@ runs:
         # download and install latest negrutiu/nsis
         outdir, outver, outarch = nsis_install(
           distro=r'${{inputs.distro}}',
+          version_in=r'${{inputs.version}}',
           arch=r'${{inputs.arch}}',
           instdir=r'${{inputs.install-dir}}',
           register_path=(r'${{inputs.register-path}}'.lower() == 'true'),


### PR DESCRIPTION
Last week my CI runs started consistently failing, and it looks like the latest update of NSIS was to blame. I need to be able to ship my application without worrying a new update will break something, so being able to pin the version and update at my convenience would be excellent.